### PR TITLE
feat: list presentations on home page instead of using header

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -1,9 +1,0 @@
----
-title: Home
-description: This is the home page.
-layout: default
----
-
-# Home Page
-
-This is the home page.

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -1,0 +1,19 @@
+---
+title: Presentations | Demonstrable
+description: Choose a presentation to give or review.
+layout: default
+---
+
+<div class="cmp-slide">
+  <h1>Presentations</h1>
+
+  <ul>
+    {% for presentation in collections.presentations %}
+    <li>
+      <a href="{{ presentation.url }}">
+        {{ presentation.data.title }}
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/pages/owasp-top-ten.njk
+++ b/pages/owasp-top-ten.njk
@@ -2,6 +2,7 @@
 title: OWASP Top Ten
 description: What are the most critical security risks that developers need to be aware of and prepared to mitigate? The Open Web Application Security Project (OWASP) tracks the most common threats and releases a Top 10 list of security risks to be aware of.
 layout: default
+tags: presentations
 ---
 
 {% for slide in collections["owasp-top-ten"] | sortByOrder %}

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -23,9 +23,7 @@
     <link rel="stylesheet" href="/styles.css">
   </head>
   <body>
-    {% block header %}
-      {% include 'partials/header.njk' %}
-    {% endblock %}
+    {% block header %}{% endblock %}
     <main id="main-content">
       {% block content %}
         {{ content | safe }}

--- a/src/partials/header.njk
+++ b/src/partials/header.njk
@@ -1,5 +1,0 @@
-<header>
-  <nav>
-    <a href="/">Home</a>
-  </nav>
-</header>


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
Controversially, I'm choosing not to provide global navigation, instead opting for a minimal home page that links to all the presentations that exist.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Make sure the home page links to the OWASP presentation and the header is gone
<!-- Add additional validation steps here -->
