### PR TITLE
feat: enable different emoji favicons for each presentation

### DIFF
--- a/pages/owasp-top-ten.njk
+++ b/pages/owasp-top-ten.njk
@@ -1,12 +1,19 @@
 ---
 title: OWASP Top Ten
 description: What are the most critical security risks that developers need to be aware of and prepared to mitigate? The Open Web Application Security Project (OWASP) tracks the most common threats and releases a Top 10 list of security risks to be aware of.
-layout: default
 tags: presentations
 ---
 
+{% extends 'layout.njk' %}
+
+{% block favicon %}
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐝</text></svg>">
+{% endblock %}
+
+{% block content %}
 {% for slide in collections["owasp-top-ten"] | sortByOrder %}
 <div class="cmp-slide">
   {{ slide.content | safe }}
 </div>
 {% endfor %}
+{% endblock %}

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -9,9 +9,9 @@
     <meta name="description" content="{{ description }}">
     {% endblock %}
 
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <link rel="alternate icon" href="/favicon.png" type="image/png">
-    <link rel="mask-icon" href="/favicon.svg">
+    {% block favicon %}
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧑‍💻</text></svg>">
+    {% endblock %}
 
     <link rel="apple-touch-icon" href="/maskable_icon.png">
     <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This enables emoji favicons to represent each presentation.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Make sure the favicon is different on each page (technologist on home page, bee on OWASP page)
<!-- Add additional validation steps here -->
