### PR TITLE
feat: revert "block codepen embeds when consent isn't granted"

### DIFF
--- a/pages/introduction-to-container-queries.njk
+++ b/pages/introduction-to-container-queries.njk
@@ -19,31 +19,5 @@ tags: presentations
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
-<script>
-  const loadPens = () => {
-    window.__CPEmbed?.('.codepen-later');
-  };
-
-  const listenForPermissionToLoadPens = () => {
-    document.querySelectorAll('.grant-codepen-consent').forEach((button) => {
-      button.addEventListener('click', () => {
-        localStorage.setItem('cp-functional-cookie-consent', 'granted');
-        loadPens();
-      });
-    });
-  }
-
-  const checkCodepenConsent = () => {
-    const consent = localStorage.getItem('cp-functional-cookie-consent');
-    if (consent === 'granted') {
-      loadPens();
-      return;
-    }
-
-    listenForPermissionToLoadPens();
-  };
-
-  checkCodepenConsent();
-</script>
+<script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 {% endblock %}

--- a/pages/slides/introduction-to-container-queries/18-newsletter-signup-form.md
+++ b/pages/slides/introduction-to-container-queries/18-newsletter-signup-form.md
@@ -4,9 +4,8 @@ order: 18
 
 ### Newsletter Signup Form
 
-<div class="codepen-later" data-slug-hash="RwYRjrE" data-user="dustin-jw">
-  <p>
-    Codepen uses a functional cookie that requires consent. If you'd rather not grant consent, you can see <a href="https://codepen.io/dustin-jw/pen/RwYRjrE">the pen on Codepen</a>.
-  </p>
-  <button type="button" class="grant-codepen-consent">Grant consent and load the embed</button>
-</div>
+<p class="codepen" data-height="600" data-default-tab="result" data-slug-hash="RwYRjrE" data-user="dustin-jw" style="height: 600px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
+  <span>See the Pen <a href="https://codepen.io/dustin-jw/pen/RwYRjrE">
+  Newsletter Signup Form w/ Container Queries</a> by Dustin Whisman (<a href="https://codepen.io/dustin-jw">@dustin-jw</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>

--- a/pages/slides/introduction-to-container-queries/19-pagination.md
+++ b/pages/slides/introduction-to-container-queries/19-pagination.md
@@ -4,9 +4,8 @@ order: 19
 
 ### Pagination
 
-<div class="codepen-later" data-slug-hash="MWqevXz" data-user="dustin-jw">
-  <p>
-    Codepen uses a functional cookie that requires consent. If you'd rather not grant consent, you can see <a href="https://codepen.io/dustin-jw/pen/MWqevXz">the pen on Codepen</a>.
-  </p>
-  <button type="button" class="grant-codepen-consent">Grant consent and load the embed</button>
-</div>
+<p class="codepen" data-height="600" data-default-tab="result" data-slug-hash="MWqevXz" data-user="dustin-jw" style="height: 600px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
+  <span>See the Pen <a href="https://codepen.io/dustin-jw/pen/MWqevXz">
+  Pagination w/ Container Queries</a> by Dustin Whisman (<a href="https://codepen.io/dustin-jw">@dustin-jw</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>

--- a/pages/slides/introduction-to-container-queries/20-cards.md
+++ b/pages/slides/introduction-to-container-queries/20-cards.md
@@ -4,9 +4,8 @@ order: 20
 
 ### Cards
 
-<div class="codepen-later" data-slug-hash="wvEGQJK" data-user="dustin-jw">
-  <p>
-    Codepen uses a functional cookie that requires consent. If you'd rather not grant consent, you can see <a href="https://codepen.io/dustin-jw/pen/wvEGQJK">the pen on Codepen</a>.
-  </p>
-  <button type="button" class="grant-codepen-consent">Grant consent and load the embed</button>
-</div>
+<p class="codepen" data-height="600" data-default-tab="result" data-slug-hash="wvEGQJK" data-user="dustin-jw" style="height: 600px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
+  <span>See the Pen <a href="https://codepen.io/dustin-jw/pen/wvEGQJK">
+  Cards w/ Container Queries</a> by Dustin Whisman (<a href="https://codepen.io/dustin-jw">@dustin-jw</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>

--- a/pages/slides/introduction-to-container-queries/21-inline-form.md
+++ b/pages/slides/introduction-to-container-queries/21-inline-form.md
@@ -4,9 +4,8 @@ order: 21
 
 ### Inline Form
 
-<div class="codepen-later" data-slug-hash="RwYaaMe" data-user="dustin-jw">
-  <p>
-    Codepen uses a functional cookie that requires consent. If you'd rather not grant consent, you can see <a href="https://codepen.io/dustin-jw/pen/RwYaaMe">the pen on Codepen</a>.
-  </p>
-  <button type="button" class="grant-codepen-consent">Grant consent and load the embed</button>
-</div>
+<p class="codepen" data-height="600" data-default-tab="result" data-slug-hash="RwYaaMe" data-user="dustin-jw" style="height: 600px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
+  <span>See the Pen <a href="https://codepen.io/dustin-jw/pen/RwYaaMe">
+  Inline Form w/ Container Queries</a> by Dustin Whisman (<a href="https://codepen.io/dustin-jw">@dustin-jw</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>

--- a/src/css/vendor.codepen.css
+++ b/src/css/vendor.codepen.css
@@ -11,14 +11,3 @@
 .cp_embed_wrapper > iframe {
   height: 100%;
 }
-
-.grant-codepen-consent {
-  margin-block-start: 1rem;
-  padding: 0.25rem 0.5rem;
-  font: inherit;
-  background-color: var(--paper);
-  color: var(--ink);
-  border: 1px solid var(--ink);
-  border-radius: 0.25rem;
-  box-shadow: 3px 3px 0 0 #666;
-}


### PR DESCRIPTION
This reverts commit 8a2cafb5d25f44b4e20ec74520c88753a0b62e06.

## Description

<!-- Add a description of work done here -->
After getting some clarification from Codepen, there shouldn't be a problem with showing Codepen embeds by default. All cookies are strictly necessary. Disclosure might theoretically be necessary, but no user data is tracked, so that might not apply. Not a lawyer!

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
<!-- Add additional validation steps here -->
